### PR TITLE
release: v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ webhook: https://discordapp.com/api/webhooks/xxx/yyy
 
 Config load order is:
 
-1. `--config` option
-2. `./discorder.yaml`
+1. `$DISCORDER_CONFIG_PATH` environment variable
+2. `--config` option
 3. `./discorder.yml`
-4. `~/.config/discorder/discorder.yaml`
-5. `~/.config/discorder/discorder.yaml`
+4. `./discorder.yaml`
+5. `~/.config/discorder/discorder.yml`
+6. `~/.config/discorder/discorder.yaml`

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Config load order is:
 1. `--config` option
 2. `./discorder.yaml`
 3. `./discorder.yml`
-4. `~/.config/discorder/config.yaml`
-5. `~/.config/discorder/config.yaml`
+4. `~/.config/discorder/discorder.yaml`
+5. `~/.config/discorder/discorder.yaml`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Options:
   -f, --file <FILE>        A file to send
   -c, --config <CONFIG>    Config file path [default: ./discorder.yaml]
   -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ## Installation

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ static CONFIG_DEFAULT_PATHS: [&str; 4] = [
     "~/.config/discorder/discorder.yaml",
 ];
 
+static CONFIG_PATH_ENV_KEY: &str = "DISCORDER_CONFIG_PATH";
+
 /// A cli tool for sending text or file to Discord Webhook
 #[derive(Parser)]
 #[command(version)]
@@ -51,6 +53,9 @@ fn load_config(path: Option<String>) -> Result<Option<Yaml>, Box<dyn std::error:
             .find(|path| Path::new(path).exists())
             .unwrap_or_else(|| "".to_owned())
     });
+    let path = std::env::var(CONFIG_PATH_ENV_KEY)
+        .map(|path| resolve_path(&path))
+        .unwrap_or(path);
     let mut file = match File::open(path) {
         Ok(file) => file,
         Err(_) => return Ok(None),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,14 +35,21 @@ struct Args {
     config: Option<String>,
 }
 
+fn resolve_path(path: &str) -> String {
+    if path.starts_with('~') {
+        let home = std::env::var("HOME").unwrap();
+        return path.replace('~', &home);
+    }
+    path.to_owned()
+}
+
 fn load_config(path: Option<String>) -> Result<Option<Yaml>, Box<dyn std::error::Error>> {
     let path = path.unwrap_or_else(|| {
         CONFIG_DEFAULT_PATHS
             .iter()
+            .map(|path| resolve_path(path))
             .find(|path| Path::new(path).exists())
-            .unwrap_or(&CONFIG_DEFAULT_PATHS[0])
-            .to_owned()
-            .to_string()
+            .unwrap_or_else(|| "".to_owned())
     });
     let mut file = match File::open(path) {
         Ok(file) => file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ static CONFIG_DEFAULT_PATHS: [&str; 4] = [
 
 /// A cli tool for sending text or file to Discord Webhook
 #[derive(Parser)]
+#[command(version)]
 struct Args {
     /// Discord Webhook URL
     #[clap(short, long)]


### PR DESCRIPTION
- feat: version option
- feat: load config from environment variable
- fix: collectively resolve path start with `~`
- docs: update README